### PR TITLE
fix: stop logger teardown from closing process stdout

### DIFF
--- a/launch/utilities/logger.py
+++ b/launch/utilities/logger.py
@@ -9,6 +9,25 @@ from rich.logging import RichHandler
 import io, sys
 from rich.console import Console
 
+# A fresh TextIOWrapper around sys.stdout.buffer per setup_logger call closes
+# the underlying buffer (= process stdout) once the wrapper is garbage
+# collected after clean_logger removes the handler. The next setup_logger call
+# in the same process (e.g. the organize stage after the setup stage) then
+# fails with "ValueError: I/O operation on closed file". Share a single,
+# never-collected console instead.
+_shared_console: Console | None = None
+
+
+def _get_shared_console() -> Console:
+    global _shared_console
+    if _shared_console is None:
+        # Wrap stdout in a UTF-8 TextIOWrapper; replace any bad chars defensively
+        utf8_stdout = io.TextIOWrapper(
+            sys.stdout.buffer, encoding="utf-8", errors="replace"
+        )
+        _shared_console = Console(file=utf8_stdout, soft_wrap=True)
+    return _shared_console
+
 
 def setup_logger(instance_id: str, log_file: Path | list[Path], printing: bool = True) -> logging.Logger:
     """
@@ -43,10 +62,7 @@ def setup_logger(instance_id: str, log_file: Path | list[Path], printing: bool =
     # logger.addHandler(ch)
     # add rich handler
     if printing:
-        # Wrap stdout in a UTF-8 TextIOWrapper; replace any bad chars defensively
-        utf8_stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
-        console = Console(file=utf8_stdout, soft_wrap=True)
-        rh = RichHandler(console=console, rich_tracebacks=True, show_path=False)
+        rh = RichHandler(console=_get_shared_console(), rich_tracebacks=True, show_path=False)
         rh.setLevel(logging.INFO)
         logger.addHandler(rh)
     return logger

--- a/launch/utilities/logger.py
+++ b/launch/utilities/logger.py
@@ -1,23 +1,15 @@
 """
 Logging utilities for launch operations with file and console output.
 """
+import io, sys
 import logging
 from pathlib import Path
-
 from rich.logging import RichHandler
-
-import io, sys
 from rich.console import Console
 
-# A fresh TextIOWrapper around sys.stdout.buffer per setup_logger call closes
-# the underlying buffer (= process stdout) once the wrapper is garbage
-# collected after clean_logger removes the handler. The next setup_logger call
-# in the same process (e.g. the organize stage after the setup stage) then
-# fails with "ValueError: I/O operation on closed file". Share a single,
-# never-collected console instead.
+
+# https://github.com/microsoft/RepoLaunch/pull/31
 _shared_console: Console | None = None
-
-
 def _get_shared_console() -> Console:
     global _shared_console
     if _shared_console is None:

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -1,0 +1,72 @@
+import gc
+import io
+import sys
+
+from launch.utilities import logger as logger_module
+
+
+class FakeStdout:
+    def __init__(self):
+        self.buffer = io.BytesIO()
+        self.encoding = "utf-8"
+        self.errors = "replace"
+
+    def write(self, text: str) -> int:
+        return len(text)
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return False
+
+
+def _drop_shared_console_without_closing_buffer() -> None:
+    console = getattr(logger_module, "_shared_console", None)
+    stream = getattr(console, "file", None)
+    if stream is not None and hasattr(stream, "detach"):
+        try:
+            stream.detach()
+        except (ValueError, OSError, io.UnsupportedOperation):
+            pass
+
+    if hasattr(logger_module, "_shared_console"):
+        logger_module._shared_console = None
+
+
+def test_repeated_console_logger_setup_keeps_stdout_buffer_open(
+    tmp_path, monkeypatch
+):
+    '''
+    Issue #30
+    FAIL_TO_PASS at PR#31
+    '''
+    logger_name = "test_repeated_console_logger_setup"
+    fake_stdout = FakeStdout()
+
+    _drop_shared_console_without_closing_buffer()
+    monkeypatch.setattr(sys, "stdout", fake_stdout)
+
+    try:
+        setup_logger = logger_module.setup_logger(
+            logger_name, tmp_path / "setup.log", printing=True
+        )
+        setup_logger.info("setup stage")
+        logger_module.clean_logger(setup_logger)
+        del setup_logger
+        gc.collect()
+
+        assert not fake_stdout.buffer.closed
+
+        organize_logger = logger_module.setup_logger(
+            logger_name, tmp_path / "organize.log", printing=True
+        )
+        organize_logger.info("organize stage")
+        logger_module.clean_logger(organize_logger)
+        del organize_logger
+        gc.collect()
+
+        assert not fake_stdout.buffer.closed
+    finally:
+        logger_module.clean_logger(logger_name)
+        _drop_shared_console_without_closing_buffer()


### PR DESCRIPTION
Fixes #30.

`setup_logger` wraps `sys.stdout.buffer` in a new `TextIOWrapper` per call; after `clean_logger` drops the `RichHandler`, garbage collection of that wrapper closes the underlying buffer — the process's real stdout. The next `setup_logger` call in the same process (organize stage after setup stage) then raises `ValueError: I/O operation on closed file`, and `run_organize`'s own `console.print` crashes with the same error while reporting it, masking the root cause.

## Change

`launch/utilities/logger.py` only: create the UTF-8-wrapped rich `Console` once at module level (`_get_shared_console`) and reuse it for every `RichHandler`, so the wrapper is never collected and stdout stays open across logger setup/teardown cycles. Behavior (UTF-8 re-encoding with `errors="replace"`, soft wrap) is unchanged.

## Verification

```python
import gc, sys, tempfile
from pathlib import Path
from launch.utilities.logger import setup_logger, clean_logger

d = Path(tempfile.mkdtemp())
for i in range(2):
    lg = setup_logger(f"inst{i}", [d / f"l{i}.log"], printing=True)
    lg.info("cycle %d", i)
    clean_logger(lg)
    gc.collect()

sys.stdout.buffer.write(b"stdout alive\n")  # raised ValueError before this fix
```

Also verified end-to-end on a private monorepo task: before the fix, the organize stage failed immediately after a successful setup stage with `I/O operation on closed file`; with the fix it proceeds into the organize agents.