### PR TITLE
fix(organize): surface parser execution errors to the agent

### DIFF
--- a/launch/agent/organize/parselog.py
+++ b/launch/agent/organize/parselog.py
@@ -173,15 +173,16 @@ def generate_log_parser(state: AgentState, max_steps: int = 20) -> dict:
             try:
                 result = run_parser(improved_parser, test_output)
                 if not isinstance(result, dict):
+                    truncated_result = str(result)
+                    if len(truncated_result) > 40000:
+                        truncated_result = truncated_result[:40000] + "\n...result truncated due to length...\n"
                     content = (
-                        "Your python parser must return a dict[str, Literal['pass', "
-                        f"'fail', 'skip']], but it produced type {type(result).__name__}. "
-                        f"The value or error it returned was:\n{result}\n"
-                        "If the above is a traceback, fix the parser so it does not "
-                        "raise. Note: the log passed to your parser is the raw stdout "
-                        "of your last command and may include the echoed command line "
-                        "and the shell prompt, so strip any non-report lines before "
-                        "parsing."
+                        f"Your python parser script must return a dict[str, Literal['pass', 'fail', 'skip']]."
+                        f"However, it produced type {type(result).__name__}. The value or error your parser returned was:\n{truncated_result}\n"
+                        "If the above is a traceback, fix the parser so it does not raise. "
+                        "Note: the log passed into your parser is the raw stdout of your last command and may include the echoed command line "
+                        "and the shell prompt, so your parser should be able to strip/ignore non-report lines.\n"
+                        "Now adjust your parser script to make sure it returns the required format."
                     )
                     return ParseLogObservation(content=content, is_stop=False)
                 improved_test_status = result

--- a/launch/agent/organize/parselog.py
+++ b/launch/agent/organize/parselog.py
@@ -173,7 +173,16 @@ def generate_log_parser(state: AgentState, max_steps: int = 20) -> dict:
             try:
                 result = run_parser(improved_parser, test_output)
                 if not isinstance(result, dict):
-                    content = f"Your python parser script should return a dict[str, Literal['pass', 'fail', 'skip']]. However, your script returned type {type(result)}. Please adjust your parser script to make sure it returns the correct format."
+                    content = (
+                        "Your python parser must return a dict[str, Literal['pass', "
+                        f"'fail', 'skip']], but it produced type {type(result).__name__}. "
+                        f"The value or error it returned was:\n{result}\n"
+                        "If the above is a traceback, fix the parser so it does not "
+                        "raise. Note: the log passed to your parser is the raw stdout "
+                        "of your last command and may include the echoed command line "
+                        "and the shell prompt, so strip any non-report lines before "
+                        "parsing."
+                    )
                     return ParseLogObservation(content=content, is_stop=False)
                 improved_test_status = result
                 truncated_result = json.dumps(result, indent=2)

--- a/launch/agent/organize/testall.py
+++ b/launch/agent/organize/testall.py
@@ -355,7 +355,16 @@ def organize_test_cmd(state: AgentState, max_steps: int) -> dict:
             #    test_output = session.send_command(print_command).output        
             result = run_parser(action.args, test_output)
             if (not isinstance(result, dict)):
-                content = f"Your python parser script should return a dict[str, Literal['pass', 'fail', 'skip']]. However, your script returned type {type(result)}. Please adjust your parser script to make sure it returns the correct format."
+                content = (
+                    "Your python parser must return a dict[str, Literal['pass', "
+                    f"'fail', 'skip']], but it produced type {type(result).__name__}. "
+                    f"The value or error it returned was:\n{result}\n"
+                    "If the above is a traceback, fix the parser so it does not "
+                    "raise. Note: the log passed to your parser is the raw stdout "
+                    "of your last command and may include the echoed command line "
+                    "and the shell prompt, so strip any non-report lines before "
+                    "parsing."
+                )
                 return SetupObservation(content=content, is_stop=False)
             if not result:
                 content = (

--- a/launch/agent/organize/testall.py
+++ b/launch/agent/organize/testall.py
@@ -355,15 +355,16 @@ def organize_test_cmd(state: AgentState, max_steps: int) -> dict:
             #    test_output = session.send_command(print_command).output        
             result = run_parser(action.args, test_output)
             if (not isinstance(result, dict)):
+                truncated_result = str(result)
+                if len(truncated_result) > 40000:
+                    truncated_result = truncated_result[:40000] + "\n...result truncated due to length...\n"
                 content = (
-                    "Your python parser must return a dict[str, Literal['pass', "
-                    f"'fail', 'skip']], but it produced type {type(result).__name__}. "
-                    f"The value or error it returned was:\n{result}\n"
-                    "If the above is a traceback, fix the parser so it does not "
-                    "raise. Note: the log passed to your parser is the raw stdout "
-                    "of your last command and may include the echoed command line "
-                    "and the shell prompt, so strip any non-report lines before "
-                    "parsing."
+                    f"Your python parser script must return a dict[str, Literal['pass', 'fail', 'skip']]."
+                    f"However, it produced type {type(result).__name__}. The value or error your parser returned was:\n{truncated_result}\n"
+                    "If the above is a traceback, fix the parser so it does not raise. "
+                    "Note: the log passed into your parser is the raw stdout of your last command and may include the echoed command line "
+                    "and the shell prompt, so your parser should be able to strip/ignore non-report lines.\n"
+                    "Now adjust your parser script to make sure it returns the required format."
                 )
                 return SetupObservation(content=content, is_stop=False)
             if not result:

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1,0 +1,34 @@
+from launch.scripts.parser import run_parser
+
+# A correct, well-formed parser that maps an XML test report to per-test status.
+GOOD_PARSER = '''
+def parser(log):
+    import xml.etree.ElementTree as ET
+    root = ET.fromstring(log)
+    return {
+        e.attrib["testName"]: e.attrib["outcome"].lower()
+        for e in root.iter()
+        if e.tag.endswith("UnitTestResult")
+    }
+'''
+
+CLEAN_LOG = '<TestRun><UnitTestResult testName="t1" outcome="Passed"/></TestRun>'
+
+# The raw stdout the harness actually passes to the parser: the echoed command
+# line precedes the report, so a strict XML/JSON parser raises on it.
+WRAPPED_LOG = "cd /testbed && cat TestResults/test-results.trx\n" + CLEAN_LOG
+
+
+def test_run_parser_returns_dict_on_clean_input():
+    assert run_parser(GOOD_PARSER, CLEAN_LOG) == {"t1": "passed"}
+
+
+def test_run_parser_surfaces_traceback_when_parser_raises():
+    # ElementTree cannot parse the command-echo-prefixed output, so the parser
+    # raises. capture_output returns the traceback as a string rather than a
+    # dict, so the traceback must be present in the result for callers to
+    # surface it back to the agent.
+    result = run_parser(GOOD_PARSER, WRAPPED_LOG)
+    assert not isinstance(result, dict)
+    assert "traceback" in result.lower()
+    assert "ParseError" in result


### PR DESCRIPTION
Fixes #32

## Problem

`run_parser` is wrapped by `capture_output`, which catches any exception raised by the agent-authored parser and returns the traceback as a string. Both call sites (`organize/testall.py`, `organize/parselog.py`) only checked `isinstance(result, dict)` and reported `type(result)`, discarding the traceback. The agent was told its parser "returned type str" with no further detail and could not recover, looping until the step budget was exhausted.

This systematically breaks strict XML/JSON report parsers (e.g. C# `dotnet test` TRX): the parser is fed the raw stdout of the last command, which includes the echoed command line before the report, so `ElementTree.fromstring` raises `ParseError`. Line-based parsers (Go/Python/JS over console text) tolerate the extra lines.

## Change

- Forward the captured value/traceback into the feedback message at both call sites.
- Tell the agent the log may include the echoed command line and shell prompt, so non-report lines should be stripped before parsing.
- Add `tests/parser_test.py` covering the clean path (returns a dict) and the raising path (traceback string is surfaced).

## Test

```
pip install -e ".[test]"
pytest -rA tests/parser_test.py
```
