### PR TITLE
fix(setup/verify): guard None action before dereferencing in verify loop

### DIFF
--- a/launch/agent/setup/verify.py
+++ b/launch/agent/setup/verify.py
@@ -189,14 +189,14 @@ def verify(state: AgentState, max_steps: int) -> dict:
         logger.info(f"\n{response.pretty_repr()}\n\n{form_llm_cost_log(response)}\n")
         messages.append(response)
         action = parse_verify_action(response.content)
-        if action.action == "command":
+        if action and action.action == "command":
             commands.append(action.args)
         observation = observation_for_verify_action(action, session)
         message = HumanMessage(f"Observation:\n{observation.content}")
         # print(message.pretty_repr())
         logger.info(message.pretty_repr())
         messages.append(message)
-        if action.action == "issue":
+        if action and action.action == "issue":
             if observation.content == "":
                 success = True
                 logger.info("The setup is successful")

--- a/tests/verify_test.py
+++ b/tests/verify_test.py
@@ -1,0 +1,20 @@
+from launch.agent.setup.verify import (
+    observation_for_verify_action,
+    parse_verify_action,
+)
+
+
+def test_parse_verify_action_returns_none_for_unparseable_response():
+    # A reply that contains no well-formed `Action:` block cannot be parsed
+    # into a VerifyAction, so parse_verify_action returns None.
+    assert parse_verify_action("Thought: the environment builds fine.") is None
+    assert parse_verify_action("") is None
+
+
+def test_observation_for_verify_action_handles_none_without_crashing():
+    # None is an expected value (see the type hint VerifyAction | None); the
+    # observation helper routes it back to the agent as a format reminder and
+    # never touches the session, so the verify loop must not dereference the
+    # action before this point.
+    obs = observation_for_verify_action(None, None)
+    assert "Action" in obs.content

--- a/tests/verify_test.py
+++ b/tests/verify_test.py
@@ -4,11 +4,23 @@ from launch.agent.setup.verify import (
 )
 
 
-def test_parse_verify_action_returns_none_for_unparseable_response():
+def test_parse_verify_action_return_value():
     # A reply that contains no well-formed `Action:` block cannot be parsed
     # into a VerifyAction, so parse_verify_action returns None.
     assert parse_verify_action("Thought: the environment builds fine.") is None
     assert parse_verify_action("") is None
+    command_action = parse_verify_action("<command>ls</command>")
+    assert command_action is not None
+    assert command_action.action == "command"
+    assert command_action.args == "ls"
+    success_action = parse_verify_action("<issue>None</issue>")
+    assert success_action is not None
+    assert success_action.action == "issue"
+    assert success_action.args == "none"
+    issue_action = parse_verify_action("<issue>The repo is ONLY partially build.</issue>")
+    assert issue_action is not None
+    assert issue_action.action == "issue"
+    assert issue_action.args == "the repo is only partially build."
 
 
 def test_observation_for_verify_action_handles_none_without_crashing():
@@ -17,4 +29,4 @@ def test_observation_for_verify_action_handles_none_without_crashing():
     # never touches the session, so the verify loop must not dereference the
     # action before this point.
     obs = observation_for_verify_action(None, None)
-    assert "Action" in obs.content
+    assert "Please using following format after `Action: `" in obs.content


### PR DESCRIPTION
Fixes #33

## Problem

`parse_verify_action()` is typed `VerifyAction | None` and returns `None` when the LLM reply contains no parseable `Action` block (prose-only, empty, or malformed). The verify loop dereferenced `action.action` without a None check, raising `AttributeError` and aborting the whole setup-verify phase.

## Change

- Guard the two `action.action` reads in the verify loop with `if action and ...`.
- `observation_for_verify_action()` already handles `None` by returning a format reminder, so an unparseable reply is now routed back to the agent instead of crashing.
- Add `tests/verify_test.py` covering the None parse result and the None-tolerant observation.

## Test

```
pip install -e ".[test]"
pytest -rA tests/verify_test.py
```
